### PR TITLE
Update CHANGELOG for version 5.1.3 to reflect the fix in plugin zipfi…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+[5.1.3] - 27 Jan, 2026
+
+- Fixed: Fix plugin zipfile naming by changing from plugin-slug to plugin-name.
+
 [5.1.2] - 22 Jan, 2026
 
 - Fixed: Fixed the deprecated `pbuild` command adding support for using the correct params of `build`.

--- a/base/generic/scripts/plugin-zipfile
+++ b/base/generic/scripts/plugin-zipfile
@@ -20,4 +20,4 @@ if [[ "$1" == "--help" || "$1" == "-h" ]]; then
 fi
 
 # Output the ZIP file name
-echo "$(plugin-slug)-$(plugin-version).zip"
+echo "$(plugin-name)-$(plugin-version).zip"


### PR DESCRIPTION
…le naming from 'plugin-slug' to 'plugin-name'. (#12)

* Fix plugin zipfile naming by changing 'plugin-slug' to 'plugin-name' in output

* Update CHANGELOG for version 5.1.3 to reflect the fix in plugin zipfile naming from 'plugin-slug' to 'plugin-name'.